### PR TITLE
Bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Terminitor is a deep neural network that predicts whether a sequence contains a polyadenylated (poly(A)) cleavage site (CS) at certain position.
 
-For more information, please refer to the preprint: https://www.biorxiv.org/content/10.1101/710699v1
+For more information, please refer to the preprint: https://www.biorxiv.org/content/10.1101/710699v2
 
 ### Datasets for download  
 www.bcgsc.ca/downloads/supplementary/Terminitor  

--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@ This ftp site contains two datasets, human and mouse, and two corresponding pre-
 * Keras
 * Scikit-learn  
 * Pybedtools  
-* Pysam  
+* Pysam
+* HTSeq  
+
+A Python environment for these packages can be created with `conda`, e.g.
+```
+conda create --name terminitor pysam pybedtools numpy keras scikit-learn htseq
+```
+For more information, consult the [user guide for conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html).
 
 ### Train  
 
@@ -30,6 +37,36 @@ optional arguments:
   -non NON       Non-CS, fasta file
   -model MODEL   File name of trained model
   -l L           Length of input sequences
+```
+
+### Extract candidate sequence  
+
+Usage: `extract_from_sequences.py [-h] [-v] -t ANNOT_TRANS -a ANNOT_ALL -m ALN
+                                 -g GENOME -o O [-u UP_LEN] [-d DOWN_LEN]`  
+
+```
+optional arguments:
+  -h, --help            show this help message and exit
+  -v, --version         show program's version number and exit
+  -t ANNOT_TRANS, --annot_trans ANNOT_TRANS
+                        Transcript annotation file, GTF format. This file
+                        contains only transcript level annotation, can be
+                        downloaded from the ftp site provided on our Github
+                        page
+  -a ANNOT_ALL, --annot_all ANNOT_ALL
+                        Ensembl annotation file, GTF format. Can be downloaded
+                        from Ensembl ftp site
+  -m ALN, --aln ALN     The alignment file from assembled transcript contigs
+                        to reference genome in BAM format.
+  -g GENOME, --genome GENOME
+                        Indexed reference genome assembly in FASTA format, which
+                        can be downloaded from Ensembl
+  -o O                  Output file, fasta format containing candidate
+                        sequences to be tested
+  -u UP_LEN, --up_len UP_LEN
+                        Upstream sequence length
+  -d DOWN_LEN, --down_len DOWN_LEN
+                        Downstream sequence length
 ```
 
 ### Test
@@ -51,46 +88,37 @@ optional arguments:
 
 ### Pipeline
 
-1. For Illumina RNA-seq short reads, run assembly with [RNA-Bloom](https://github.com/bcgsc/RNA-Bloom)  
-`java -jar RNA-Bloom.jar -left read2.fq -right read1.fq -revcomp-right -outdir assembly -a 4 -e 1 -stratum 01 -ss -ntcard -fpr 0.005`  
+1. For Illumina RNA-seq short reads, run assembly with [RNA-Bloom](https://github.com/bcgsc/RNA-Bloom)
+```
+java -jar RNA-Bloom.jar -left read2.fq -right read1.fq -revcomp-right -outdir assembly -a 4 -e 1 -stratum 01 -ss -ntcard -fpr 0.005
+```  
 For PacBio CCS reads, skip this step  
 
 2. Genome alignment with [minimap2](https://github.com/lh3/minimap2)    
-`minimap2 -ax splice hg38.mmi rnabloom.transcripts.fa | samtools view -b - > aln.bam`  
+```
+minimap2 -ax splice hg38.mmi rnabloom.transcripts.fa | samtools view -u - | samtools sort -T tmp_prefix -O BAM -o aln.bam
+samtools index aln.bam
+```  
 
 3. Extract candidate sequence  
-`./src/extract_from_sequences.py -t Homo_sapiens.GRCh38.94.transcripts.gtf -a Homo_sapiens.GRCh38.94.chr.gtf -g Homo_sapiens.GRCh38.dna.primary_assembly.fa -m aln.bam -o test`  
-Details are explained below.  
+```
+python extract_from_sequences.py -t Homo_sapiens.GRCh38.99.transcripts.gtf -a Homo_sapiens.GRCh38.99.gtf -g Homo_sapiens.GRCh38.dna.primary_assembly.fa -m aln.bam -o extracted_sequences.fa
+```
+
+The GTF file for `-a` option can be downloaded from Ensembl.
+  
+The GTF file for `-t` option can be generated based on the Ensembl annotation, e.g.
+```
+awk '$3=="transcript" {print}' Homo_sapiens.GRCh38.99.gtf > Homo_sapiens.GRCh38.99.transcripts.gtf
+```
+
+The reference genome for `-g` option can be downloaded from Ensembl and must be indexed, e.g.
+```
+samtools faidx Homo_sapiens.GRCh38.dna.primary_assembly.fa
+```
 
 4. Test  
-`./test.py -t extracted_sequence.fa -m pre_trained_model -l 200 -o output`  
-
-### Extract candidate sequence  
-
-Usage: `extract_from_sequences.py [-h] [-v] -t ANNOT_TRANS -a ANNOT_ALL -m ALN
-                                 -g GENOME -o O [-u UP_LEN] [-d DOWN_LEN]`  
-
 ```
-optional arguments:
-  -h, --help            show this help message and exit
-  -v, --version         show program's version number and exit
-  -t ANNOT_TRANS, --annot_trans ANNOT_TRANS
-                        Transcript annotation file, GTF format. This file
-                        contains onlytranscript level annotation, can be
-                        downloaded from the ftp siteprovided on our Github
-                        page
-  -a ANNOT_ALL, --annot_all ANNOT_ALL
-                        Ensembl annotation file, GTF format. Can be downloaded
-                        from Ensemblftp site
-  -m ALN, --aln ALN     The alignment file from assembled transcript contigs
-                        to reference genomein bam format.
-  -g GENOME, --genome GENOME
-                        Reference genome assembly in Fasta format. Can be
-                        downloaded fromEnsembl ftp site
-  -o O                  Output file, fasta format containing candidate
-                        sequences to be tested
-  -u UP_LEN, --up_len UP_LEN
-                        Upstream sequence length
-  -d DOWN_LEN, --down_len DOWN_LEN
-                        Downstream sequence length
-```
+python test.py -t extracted_sequences.fa -m pre_trained_model -l 200 -o probablities.txt
+```  
+

--- a/src/extract_from_sequences.py
+++ b/src/extract_from_sequences.py
@@ -8,6 +8,7 @@ Major change on Oct 17th, adopting Design 9
 '''
 
 import os
+import sys
 import pysam
 import pybedtools
 import argparse

--- a/src/extract_from_sequences.py
+++ b/src/extract_from_sequences.py
@@ -4,9 +4,10 @@
 Created on Sept 11th 2018
 Major change on Oct 17th, adopting Design 9
 
-@author: Chen
+@author: Chen Yang
 '''
 
+import os
 import pysam
 import pybedtools
 import argparse
@@ -41,11 +42,11 @@ def rev_comp(seq):
     new_seq = ''.join([BASE[x] for x in new_seq])
     return new_seq
 
-
+"""
 CHR = ('chr1', 'chr2', 'chr3', 'chr4', 'chr5', 'chr6', 'chr7', 'chr8', 'chr9',
        'chr10', 'chr11', 'chr12', 'chr13', 'chr14', 'chr15', 'chr16', 'chr17',
        'chr18', 'chr19', 'chr20', 'chr21', 'chr22', 'chrX', 'chrY')
-
+"""
 
 def main():
     parser = argparse.ArgumentParser(
@@ -66,8 +67,8 @@ def main():
                                                   'ftp site', required=True)
     parser.add_argument('-m', '--aln', help='The alignment file from assembled transcript contigs to reference genome in '
                                             'bam format.', required=True)
-    parser.add_argument('-g', '--genome', help='Reference genome assembly in Fasta format. Can be downloaded from '
-                                               'Ensembl ftp site', required=True)
+    parser.add_argument('-g', '--genome', help='Indexed reference genome assembly in Fasta format, which can be downloaded from '
+                                               'Ensembl', required=True)
     parser.add_argument('-o', help='Output file, fasta format containing candidate sequences to be tested',
                         required=True)
     parser.add_argument('-u', '--up_len', help='Upstream sequence length', type=int, default=100)
@@ -83,27 +84,28 @@ def main():
     up_len = args.up_len
     down_len = args.down_len
 
-    '''
-    # Read in genome
-    chrome_len = {}
+    
+    # Read in chromosome lengths from FASTA index
+    chrom_len = {}
 
-    with open(assem, 'r') as f:
-        for line in f:
-            if line[0] == '>':
-                info = line.split()
-                name = info[0][1:]
-                length = int(info[2].split(':')[4])
-                chrome_len[name] = length
-    '''
+    if os.path.exist(assem + '.fai'):
+        with open(assem + '.fai', 'r') as f:
+            for line in f:
+                cols = line.split()
+                chrom_len[cols[0]] = int(cols[1])
+    else:
+        print('Cannot find FASTA index for reference genome, i.e. `' + assem + '.fai`')
+        sys.exit(1)
+    
 
     # GTF file is 1-based inclusive, bed file is 0-based half open
     trans_coord = {}
     gtf_features = GFF_Reader(annot_all)
     for feature in gtf_features:
         # Sometimes, 'chr' is not in the chromesome name, add it back
-        chrom = feature.iv.chrom if 'chr' in feature.iv.chrom else  'chr' + feature.iv.chrom
-        if chrom not in CHR:
-            continue
+        chrom = feature.iv.chrom #if 'chr' in feature.iv.chrom else  'chr' + feature.iv.chrom
+        #if chrom not in CHR:
+        #    continue
         if chrom not in trans_coord:
             trans_coord[chrom] = {}
         if feature.type == 'transcript':
@@ -187,9 +189,9 @@ def main():
     for info in intersect:
         feature = parse_GFF_attribute_string(info[20][:-1] + '\n')
         trans = feature['transcript_id']
-        chrom = info[0] if 'chr' in info[0] else 'chr' + info[0]
-        if chrom not in CHR:
-            continue
+        chrom = info[0] #if 'chr' in info[0] else 'chr' + info[0]
+        #if chrom not in CHR:
+        #    continue
         
         strand = info[5]
         if strand == '+':
@@ -225,9 +227,9 @@ def main():
         if read.flag != 0 and read.flag != 16:
             continue
         
-        chrom = read.reference_name if 'chr' in read.reference_name else 'chr' + read.reference_name
-        if chrom not in CHR:
-            continue
+        chrom = read.reference_name #if 'chr' in read.reference_name else 'chr' + read.reference_name
+        #if chrom not in CHR:
+        #    continue
 
         if read.flag == 0:
             strand = '+'
@@ -272,11 +274,21 @@ def main():
         if 'U' not in v:
             continue
         if info[-1] == 'F':
-            bed_string.append(info[1] + '\t' + str(int(info[2]) + 1) + '\t' + str(int(info[2]) + down_len + 1) +
+            chrom = info[1]
+            start = int(info[2]) + 1
+            end = int(info[2]) + down_len + 1
+            if start >= 0 and end < chrom_len[chrom]:
+                # interval must be valid
+                bed_string.append(chrom + '\t' + str(start) + '\t' + str(end) +
                               '\t' + k + '\t-\t+')
         else:
-            bed_string.append(info[1] + '\t' + str(int(info[2]) - down_len) + '\t' + str(int(info[2])) + '\t' + k +
-                              '\t-\t-')
+            chrom = info[1]
+            start = int(info[2]) - down_len
+            end = int(info[2])
+            if start >= 0 and end < chrom_len[chrom]:
+                # interval must be valid
+                bed_string.append(chrom + '\t' + str(start) + '\t' + str(end) +
+                              '\t' + k + '\t-\t-')
 
     down_bed = pybedtools.BedTool('\n'.join(bed_string), from_string=True)
 
@@ -292,7 +304,7 @@ def main():
     nonredundant = {}    
     for name, v in seq_dict.items():
         direction = name.split('_')[-1]
-        if 'U' not in v or len(v['U']) < up_len:
+        if 'U' not in v or 'D' not in v or len(v['U']) < up_len:
             continue
         if direction == 'F':
             seq = v['U'] + v['D']


### PR DESCRIPTION
`README.md`:
* `htseq` was missing in the list of required packages
* add more info on installing required packages with `conda`
* add more info on general usage

`extract_from_sequences.py`
* Avoid generating BED for cleavage sites near chromosome ends
* Generalize script for non-human genomes and chromosome names without the `chr` prefix
* Prevent KeyError when retrieving `D` from dictionary `V`